### PR TITLE
updated schemas for action#12 and #13.

### DIFF
--- a/APIs/pmn-topology.raml
+++ b/APIs/pmn-topology.raml
@@ -42,7 +42,9 @@ documentation:
   /{id}:
     uriParameters:
       id:
-        type: integer
+        type: string
+        description: The unique identifier for the Device. Mac-address is used
+        pattern:^([0-9A-Fa-f]{2}[:]){5}([0-9A-Fa-f]{2})$
     get:
       description: Get a single Network Device
       body:
@@ -96,7 +98,9 @@ documentation:
   /{id}:
     uriParameters:
       id:
-        type: integer
+        type: string
+        description: The unique identifier for the Device. Mac-address is used
+        pattern:^([0-9A-Fa-f]{2}[:]){5}([0-9A-Fa-f]{2})$
 
     get:
       description: Get a single Endpoint
@@ -193,5 +197,7 @@ documentation:
   /{id}:
     uriParameters:
       id:
-        type: integer
+        type: string
+        description: The unique identifier for the Device. Mac-address is used
+        pattern:^([0-9A-Fa-f]{2}[:]){5}([0-9A-Fa-f]{2})$
 

--- a/APIs/schemas/endpoint.json
+++ b/APIs/schemas/endpoint.json
@@ -3,7 +3,9 @@
   "type": "object",
   "properties": {
     "id": {
-      "type": "integer"
+      "type": "string",
+      "description": "The unique identifier for the Device. Mac-address is used",
+      "pattern":"^([0-9A-Fa-f]{2}[:]){5}([0-9A-Fa-f]{2})$"
     },
     "description": {
       "type": "string"

--- a/APIs/schemas/endpointlink.json
+++ b/APIs/schemas/endpointlink.json
@@ -3,10 +3,14 @@
   "type": "object",
   "properties": {
     "network-device-id": {
-      "type": "integer"
+      "type": "string",
+      "description": "The unique identifier for the Device. Mac-address is used",
+      "pattern":"^([0-9A-Fa-f]{2}[:]){5}([0-9A-Fa-f]{2})$"
     },
     "endpoint-id": {
-      "type": "integer"
+      "type": "string",
+      "description": "The unique identifier for the Device. Mac-address is used",
+      "pattern":"^([0-9A-Fa-f]{2}[:]){5}([0-9A-Fa-f]{2})$"
     },
     "network-interface": {
       "type": "string"

--- a/APIs/schemas/networkdevice.json
+++ b/APIs/schemas/networkdevice.json
@@ -1,9 +1,12 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
+  "title": "Network Device",
   "properties": {
     "id": {
-      "type": "integer"
+      "type": "string",
+      "description": "The unique identifier for the Device. Mac-address is used",
+      "pattern":"^([0-9A-Fa-f]{2}[:]){5}([0-9A-Fa-f]{2})$"
     },
     "name": {
       "type": "string"
@@ -22,7 +25,7 @@
     },
     "mac-address": {
       "type": "string",
-      "pattern":"^([0-9A-Fa-f]{2}[:-]){5}([0-9A-Fa-f]{2})$" 
+      "pattern":"^([0-9A-Fa-f]{2}[:]){5}([0-9A-Fa-f]{2})$" 
     },
     "mgmt-ip": {
       "type": "string"
@@ -61,11 +64,11 @@
           },
           "built-in-mac-address": {
             "type": "string",
-            "pattern":"^([0-9A-Fa-f]{2}[:-]){5}([0-9A-Fa-f]{2})$"
+            "pattern":"^([0-9A-Fa-f]{2}[:]){5}([0-9A-Fa-f]{2})$"
           },
           "mac-address": {
             "type": "string",
-            "pattern":"^([0-9A-Fa-f]{2}[:-]){5}([0-9A-Fa-f]{2})$"
+            "pattern":"^([0-9A-Fa-f]{2}[:]){5}([0-9A-Fa-f]{2})$"
           },
           "ip-address": {
             "type": "string"

--- a/APIs/schemas/networklink.json
+++ b/APIs/schemas/networklink.json
@@ -3,10 +3,14 @@
   "type": "object",
   "properties": {
     "network-device-id": {
-      "type": "integer"
+      "type": "string",
+      "description": "The unique identifier for the Device. Mac-address is used",
+      "pattern":"^([0-9A-Fa-f]{2}[:]){5}([0-9A-Fa-f]{2})$"
     },
     "peer-network-device-id": {
-      "type": "integer"
+      "type": "string",
+      "description": "The unique identifier for the Device. Mac-address is used",
+      "pattern":"^([0-9A-Fa-f]{2}[:]){5}([0-9A-Fa-f]{2})$"
     },
     "network-interface": {
       "type": "string"

--- a/APIs/schemas/topologyapi-v1.0-endpoints-post-request.json
+++ b/APIs/schemas/topologyapi-v1.0-endpoints-post-request.json
@@ -6,7 +6,9 @@
       "type": "string"
     },
     "chassis-id": {
-      "type": "string"
+      "type": "string",
+      "description": "The unique identifier for the Device. Mac-address is used",
+      "pattern":"^([0-9A-Fa-f]{2}[:]){5}([0-9A-Fa-f]{2})$"
     },
     "port-id": {
       "type": "string"

--- a/APIs/stub/sampledata/ep
+++ b/APIs/stub/sampledata/ep
@@ -1,7 +1,7 @@
 {
 "type": "endpoints",
 "data": {
-        "id":1000,
+        "id":"9c:60:4f:04:22:00",
         "description":"user defined string",
         "chassis-id": "9c:60:4f:04:22:00",
         "port-id": "9c:60:4f:04:22:41"

--- a/APIs/stub/sampledata/epLink
+++ b/APIs/stub/sampledata/epLink
@@ -1,8 +1,8 @@
 {
 "type": "endpoint-links",
 "data": {
-        "network-device-id": 101,
-        "endpoint-id": 1000,
+        "network-device-id": "8c:60:4f:04:24:41",
+        "endpoint-id": "9c:60:4f:04:22:00",
         "network-interface": "eth 1/2",
         "endpoint-port-id":"9c:60:4f:04:22:41",
         "status": "up",

--- a/APIs/stub/sampledata/nd1
+++ b/APIs/stub/sampledata/nd1
@@ -1,7 +1,7 @@
 {
 "type":"network-devices",
 "data": {
-  "id": 100,
+  "id": "8c:60:4f:04:24:41",
   "name":"switch1",
   "serial-number": "FXS1844Q1UH",
   "product-id": "N77-C7706",

--- a/APIs/stub/sampledata/nd2
+++ b/APIs/stub/sampledata/nd2
@@ -1,7 +1,7 @@
 {
 "type":"network-devices",
 "data": {
-  "id": 101,
+  "id": "8c:60:4f:04:24:41",
   "name":"switch2",
   "serial-number": "FXS1844Q1XY",
   "product-id": "N77-C7703",

--- a/APIs/stub/sampledata/ndLink
+++ b/APIs/stub/sampledata/ndLink
@@ -1,8 +1,8 @@
 {
 "type": "network-links",
 "data": {
-        "network-device-id": 100,
-        "peer-network-device-id": 101,
+        "network-device-id": "8c:60:4f:04:24:41",
+        "peer-network-device-id": "8c:60:4f:04:24:42",
         "network-interface": "eth 1/1",
         "peer-network-interface": "eth 1/1",
         "status": "up",

--- a/examples/topologyapi-v1.0-all-get-200.json
+++ b/examples/topologyapi-v1.0-all-get-200.json
@@ -2,13 +2,13 @@
   "network-devices":
   [
       {
-        "id": 100,
+        "id": "8c:60:4f:04:24:41",
         "name":"switch1",
         "serial-number": "FXS1844Q1UH",
         "product-id": "N77-C7706",
         "product-description": "Nexus 7700 C7706 (6 Slot) Chassis",
         "vendor": "Cisco",
-        "mac-address": "8c60.4f04.2441",
+        "mac-address": "8c:60:4f:04:24:41",
         "mgmt-ip": "172.25.140.249",
         "version": "7.2(0)D1(1) [build 7.2(0)AV(0.89)]",
         "image-file": "N7700-s2-dk9.7.2.0.gbin",
@@ -23,7 +23,7 @@
             "oper-status": "up",
             "down-reason": "NA",
             "built-in-mac-address":" 5cfc.666d.fa90",
-            "mac-address": "8c60.4f04.2141 (for L3, GW MAC) 5cfc.666d.fa90 (for L2, BIM) Modifiable manually",	
+            "mac-address": "8c:60:4f:04:21:41 (for L3, GW MAC) 5c:fc:66:6d:fa:90 (for L2, BIM) Modifiable manually",	
             "ip-address": "10.1.1.1",
             "operating-speed":"1G",
             "MTU": "1500",
@@ -32,13 +32,13 @@
         ] 
       },
       {
-        "id": 101,
+        "id":  "8c:60:4f:04:24:41",
         "name":"switch2",
         "serial-number": "FXS1844Q1UG",
         "product-id": "N77-C7706",
         "product-description": "Nexus 7700 C7706 (6 Slot) Chassis",
         "vendor": "Cisco",
-        "mac-address": "8c60.4f04.2441",
+        "mac-address": "8c:60:4f:04:24:41",
         "mgmt-ip": "172.25.140.249",
         "version": "7.2(0)D1(1) [build 7.2(0)AV(0.89)]",
         "image-file": "N7700-s2-dk9.7.2.0.gbin",
@@ -52,8 +52,8 @@
             "admin-status": "up",
             "oper-status": "up",
             "down-reason": "NA",
-            "built-in-mac-address":" 5cfc.666d.fb90",
-            "mac-address": "8c60.4f04.2241 (for L3, GW MAC) 5cfc.666d.fa90 (for L2, BIM) Modifiable manually",	
+            "built-in-mac-address":" 5c:fc:66:6d:fb:90",
+            "mac-address": "8c:60:4f:04:22:41 (for L3, GW MAC) 5c:fc:66:6d:fa:90 (for L2, BIM) Modifiable manually",	
             "ip-address": "10.1.1.2",
             "operating-speed":"1G",
             "MTU": "1500",
@@ -64,7 +64,7 @@
             "status": "up",
             "down-reason": "NA",
             "built-in-mac-address":" 5cfc.666d.fb91",
-            "mac-address": "8c60.4f04.2242 (for L3, GW MAC) 5cfc.666d.fa90 (for L2, BIM) Modifiable manually",	
+            "mac-address": "8c:60:4f:04:22:42 (for L3, GW MAC) 5c:fc:66:6d:fa:90 (for L2, BIM) Modifiable manually",	
             "ip-address": "10.1.1.3",
             "operating-speed":"1G",
             "MTU": "1500",
@@ -77,18 +77,18 @@
   "endpoints":
   [
       {
-        "id":1000, 
+        "id":"9c:c6:4f:04:22:00", 
         "description":"user defined string",
-        "chassis-id": "9cc60.4f04.2200",
-        "port-id": "9cc60.4f04.2241"
+        "chassis-id": "9c:c6:4f:04:22:00",
+        "port-id": "9c:c6:4f:04:22:41"
       }
   ],  
 
   "network-links":
   [
       {
-        "network-device-id": 100,
-        "peer-network-device-id": 101,
+        "network-device-id": "8c:60:4f:04:24:41",
+        "peer-network-device-id": "8c:60:4f:04:24:42",
         "network-interface": "eth 1/1",
         "peer-network-interface": "eth 1/1",
         "status": "up|down",
@@ -99,10 +99,10 @@
  "endpoint-links":
  [
       {
-        "network-device-id": 101,
-        "endpoint-id": 1000,
+        "network-device-id": "8c:60:4f:04:24:41",
+        "endpoint-id": "9c:c6:4f:04:22:00",
         "network-interface": "eth 1/2",
-        "endpoint-interface":"9cc60.4f04.2241",
+        "endpoint-interface":"9c:c6:4f:04:22:41",
         "status": "up|down",
         "speed": "1G"
       }

--- a/examples/topologyapi-v1.0-endpointid-get-200.json
+++ b/examples/topologyapi-v1.0-endpointid-get-200.json
@@ -1,5 +1,5 @@
 {
-  "id":1000, 
+  "id":"9c:60:4f:42:20:40", 
   "description":"user defined string",
   "chassis-id": "9c:60:4f:42:20:40",
   "port-id": "9c:60:4f:04:22:41"

--- a/examples/topologyapi-v1.0-endpointlinks-get-200.json
+++ b/examples/topologyapi-v1.0-endpointlinks-get-200.json
@@ -1,7 +1,7 @@
  [
       {
-        "network-device-id": 101,
-        "endpoint-id": 1000,
+        "network-device-id": "8c:60:4f:04:24:41",
+        "endpoint-id": "9c:60:4f:42:20:40",
         "network-interface": "eth 1/2",
         "endpoint-port-id":"9c:60:4f:04:22:41",
         "status": "up",

--- a/examples/topologyapi-v1.0-endpoints-delete-200.json
+++ b/examples/topologyapi-v1.0-endpoints-delete-200.json
@@ -1,6 +1,6 @@
 {
-  "id":1000,
+  "id":"9c:c6:4f:04:22:00",
   "description":"user defined string",
-  "chassis-id": "9cc60.4f04.2200",
-  "port-id": "9cc60.4f04.2241"
+  "chassis-id": "9c:c6:4f:04:22:00",
+  "port-id": "9c:c6:4f:04:22:41"
 }

--- a/examples/topologyapi-v1.0-endpoints-get-200.json
+++ b/examples/topologyapi-v1.0-endpoints-get-200.json
@@ -1,8 +1,8 @@
   [
       {
-        "id":1000, 
+        "id":"9c:c6:4f:04:22:00", 
         "description":"user defined string",
-        "chassis-id": "9c:c60:4f:04:22:00",
-        "port-id": "9c:c60:4f:04:22:41"
+        "chassis-id": "9c:c6:4f:04:22:00",
+        "port-id": "9c:c6:4f:04:22:41"
       }
   ]

--- a/examples/topologyapi-v1.0-endpoints-post-201.json
+++ b/examples/topologyapi-v1.0-endpoints-post-201.json
@@ -1,6 +1,6 @@
 {
-  "id":1000,
+  "id":"9c:60:4f:04:22:41",
   "description":"user defined string",
-  "chassis-id": "9cc60.4f04.2200",
-  "port-id": "9cc60.4f04.2241"
+  "chassis-id": "9c:60:4f:04:22:41",
+  "port-id": "9c:60:4f:04:22:41"
 }

--- a/examples/topologyapi-v1.0-networkdeviceid-get-200.json
+++ b/examples/topologyapi-v1.0-networkdeviceid-get-200.json
@@ -1,5 +1,5 @@
 {
-  "id": 100,
+  "id": "8c:60:4f:04:24:41",
   "name":"switch1",
   "serial-number": "FXS1844Q1UH",
   "product-id": "N77-C7706",

--- a/examples/topologyapi-v1.0-networkdevices-get-200.json
+++ b/examples/topologyapi-v1.0-networkdevices-get-200.json
@@ -1,6 +1,6 @@
   [
       {
-        "id": 100, 
+        "id": "8c:60:4f:04:24:41", 
         "name":"switch1",
         "serial-number": "FXS1844Q1UH",
         "product-id": "N77-C7706",
@@ -30,7 +30,7 @@
         ]
       },
       {
-        "id": 101, 
+        "id": "8c:60:4f:04:24:41", 
         "name":"switch2",
         "serial-number": "FXS1844Q1UG",
         "product-id": "N77-C7706",

--- a/examples/topologyapi-v1.0-networklinks-get-200.json
+++ b/examples/topologyapi-v1.0-networklinks-get-200.json
@@ -1,7 +1,7 @@
  [
       {
-        "network-device-id": 100,
-        "peer-network-device-id": 101,
+        "network-device-id": "8c:60:4f:04:24:41",
+        "peer-network-device-id": "8c:60:4f:04:24:42",
         "network-interface": "eth 1/1",
         "peer-network-interface": "eth 1/1",
         "status": "up",


### PR DESCRIPTION
updated schemas for action#12 and #13.
#12: To make the schemas consistent with examples directory
#13: Set all ids to mac id format. id of the schema is chassis id which is chassis's mac id. port id is port's mac id.