### PR TITLE
The "required" array in a JSON object schema MUST NOT be empty

### DIFF
--- a/APIs/schemas/endpoint-patch.json
+++ b/APIs/schemas/endpoint-patch.json
@@ -3,8 +3,6 @@
   "type": "object",
   "description": "Patch request schema for updating an existing endpoint.",
   "title": "Schema to modify an endpoint with new values.",
-  "required": [
-  ],
   "properties": {
     "ip_address": {
       "type": "string",

--- a/APIs/schemas/network-flow-patch.json
+++ b/APIs/schemas/network-flow-patch.json
@@ -3,8 +3,6 @@
   "type": "object",
   "description": "Describes a patch of a network flow.",
   "title": "Network flow with attributes that can be patched",
-  "required": [
-  ],
   "properties": {
     "bandwidth": {
       "type": "string",


### PR DESCRIPTION
See https://tools.ietf.org/html/draft-fge-json-schema-validation-00#section-5.4.3.1 and https://github.com/AMWA-TV/nmos-discovery-registration/pull/127.