### PR TITLE
Fixed bare URL links in Markdown

### DIFF
--- a/docs/1.0. Overview.md
+++ b/docs/1.0. Overview.md
@@ -6,7 +6,7 @@ _(c) AMWA 2017, CC Attribution-ShareAlike 4.0 International (CC BY-SA 4.0)_
 
 The documents included in this directory provide details and recommendations for implementations of the defined APIs, or their consumers.
 
-Familiarity with the JT-NM reference architecture (http://jt-nm.org/) is assumed.
+Familiarity with the JT-NM reference architecture (<http://jt-nm.org/>) is assumed.
 
 ## Introduction
 


### PR DESCRIPTION
Puts `<` and `>` around bare URLs so they render as links on github.io. See also https://github.com/AMWA-TV/nmos-template/issues/13