### PR TITLE
Add section on Identifier Persistence & Generation

### DIFF
--- a/APIs/NetworkControlAPI.raml
+++ b/APIs/NetworkControlAPI.raml
@@ -177,12 +177,20 @@ documentation:
             example: !include ../examples/netctrl-endpoint-id-get-200.json
           headers:
             Location:
-              example: /x-nmos/netctrl/{version}/endpoints/d0729fa2-83ba-4e6b-8817-d48a4bf28f74/
+              example: /x-nmos/netctrl/{version}/endpoints/d0729fa2-83ba-4e6b-8817-d48a4bf28f74
         400:
           description: >
             Returned when the PUT request is incorrectly formatted or has missing mandatory attributes or an attribute is invalid given the API's configuration, such as when the Endpoint ID already exists. Error responses should contain a relevant message.
           body:
             type: ErrorSchema
+        409:
+          description: >
+            Returned when the PUT request is invalid because an Endpoint with the same unique details (Chassis ID, Port ID and IP Address) already exists. The existing Endpoint is indicated via the Location header.
+          body:
+            type: ErrorSchema
+          headers:
+            Location:
+              example: /x-nmos/netctrl/{version}/endpoints/b2ff7bc0-de0c-478a-bd93-4be0b13a2ffe
     patch:
       description: Update an existing Endpoint's attributes.
       body:
@@ -296,7 +304,7 @@ documentation:
             Returned when the Network Flow is created successfully. The Location header should indicate the location of the created resource.
           headers:
             Location:
-              example: /x-nmos/netctrl/{version}/network-flows/6fb3c057-a363-40cc-8f3d-cbaee5e35248/
+              example: /x-nmos/netctrl/{version}/network-flows/6fb3c057-a363-40cc-8f3d-cbaee5e35248
           body: 
             type: NetworkFlow
             example: !include ../examples/netctrl-network-flow-id-get-200.json

--- a/APIs/NetworkControlAPI.raml
+++ b/APIs/NetworkControlAPI.raml
@@ -180,7 +180,7 @@ documentation:
               example: /x-nmos/netctrl/{version}/endpoints/d0729fa2-83ba-4e6b-8817-d48a4bf28f74
         400:
           description: >
-            Returned when the PUT request is incorrectly formatted or has missing mandatory attributes or an attribute is invalid given the API's configuration, such as when the Endpoint ID already exists. Error responses should contain a relevant message.
+            Returned when the PUT request is incorrectly formatted or has missing mandatory attributes or an attribute is invalid given the API's configuration, such as when the Endpoint ID already exists, or the network controller can identify that the details for other parameters do not agree with the information held by the network device. Error responses should contain a relevant message.
           body:
             type: ErrorSchema
         409:

--- a/docs/3.0. Data Model.md
+++ b/docs/3.0. Data Model.md
@@ -24,6 +24,8 @@ UUIDs are used throughout the data model, and can be generated in a number of wa
 
 The `chassis_id`, `port_id` and `ip_address` parameters together may be used to generate a persistent, unique `id` for an Endpoint.
 
+Note that if there are multiple IP addresses associated with a single physical endpoint then it must be modelled as multiple virtual endpoints each with a unique IP address.
+
 ### Network Flow
 
 The `multicast_address` and `sender_endpoint_id` parameters together may be used to generate a persistent, unique `id` for a Network Flow.

--- a/docs/3.0. Data Model.md
+++ b/docs/3.0. Data Model.md
@@ -10,8 +10,12 @@ The resources that are managed by the Network Control API are as follows:
 
  The broadcast controller is responsible for uniquely identifying the endpoint connected to the network to authorize it. The objective of the endpoint authorization is that no endpoint is allowed to send or receive any packet and no packet moves on the network without authorization. The broadcast controller tells the network controller through the API, which endpoint is allowed to send and which endpoint is allowed to receive. It also registers the flow, the flow bandwidth and the DSCP-based QoS tag to be used with the flow. More details can be found in the following sections.
 
-### Class diagram
-
 ![Class Diagram](images/class-diagram.png)
 
 There can be multiple broadcast controllers managing a single network controller and likewise, there can be multiple network controllers managed by the same broadcast controller. In the case of multiple broadcast controllers managing a single network controller, this specification, only supports the basic model. This means that there is no separation between the broadcast controllers. In other words, if a broadcast controller A registers an endpoint SS, then a broadcast controller B can retrieve, modify and delete that endpoint SS.
+
+## Identifier Persistence & Generation
+
+Persistent identity helps to ensure that users' expectations meet with reality. For example, if a network device is switched off and back on, the user would expect it to return with the same configuration. This can only be managed if the identifiers used by the network controller and its clients remain the same.
+
+UUIDs are used throughout the data model, and can be generated in a number of ways (including from hardware addresses) in order to achieve consistent behaviour (see [RFC 4122](https://tools.ietf.org/html/rfc4122)).

--- a/docs/3.0. Data Model.md
+++ b/docs/3.0. Data Model.md
@@ -19,3 +19,19 @@ There can be multiple broadcast controllers managing a single network controller
 Persistent identity helps to ensure that users' expectations meet with reality. For example, if a network device is switched off and back on, the user would expect it to return with the same configuration. This can only be managed if the identifiers used by the network controller and its clients remain the same.
 
 UUIDs are used throughout the data model, and can be generated in a number of ways (including from hardware addresses) in order to achieve consistent behaviour (see [RFC 4122](https://tools.ietf.org/html/rfc4122)).
+ 
+### Endpoint
+
+The `chassis_id`, `port_id` and `ip_address` parameters together may be used to generate a persistent, unique `id` for an Endpoint.
+
+### Network Flow
+
+The `multicast_address` and `sender_endpoint_id` parameters together may be used to generate a persistent, unique `id` for a Network Flow.
+
+### Network Device
+
+The `chassis_id` parameter may be used to generate a persistent, unique `id` for a Network Device.
+
+### Network Link
+
+Network Links do not have a unique `id`. They are identified by the peer devices in the link.


### PR DESCRIPTION
(based on the [Identifier Persistence & Generation](https://amwa-tv.github.io/nmos-discovery-registration/tags/v1.3/docs/5.1._Data_Model_-_Identifier_Mapping.html#identifier-persistence--generation) section in IS-04)

Intended to resolve #23.
