### PR TITLE
A second attempt to resolve the LLDP situation

### DIFF
--- a/APIs/NetworkControlAPI.raml
+++ b/APIs/NetworkControlAPI.raml
@@ -164,7 +164,14 @@ documentation:
             type: ErrorSchema
     put:
       description: >
-        Register a new Endpoint. The PUT is invoked to inform the network controller about the presence of an Endpoint. The Endpoint schema includes mandatory details of the Network Device the Endpoint is attached to. The attached network device details can be fetched by the endpoint through LLDP (if the endpoint is LLDP capable) or manual entry in the caller of this API (e.g., a broadcast controller). The network _may_ verify these details for security purposes. Verification _may_ happen synchronously, as part of the request. The network controller _must_ create a corresponding Network Link with this Endpoint as the peer device. Subsequent PUT requests should receive an error response. Updates should be done using PATCH.
+        Register a new Endpoint.
+        The PUT is invoked to inform the network controller about the presence of an Endpoint.
+        The Endpoint schema includes mandatory details of the Network Device the Endpoint is attached to.
+        The attached network device details can be fetched by the endpoint through LLDP (if the endpoint is LLDP capable)
+        or manual entry in the caller of this API (e.g., a broadcast controller).
+        The network _may_ verify these details for security purposes. Verification _may_ happen synchronously, as part of the request.
+        The network controller _must_ create a corresponding Network Link with this Endpoint as the peer device.
+        Subsequent PUT requests should receive an error response. Updates should be done using PATCH.
       body:
         type: Endpoint
         example: !include ../examples/netctrl-endpoint-put-request.json

--- a/APIs/NetworkControlAPI.raml
+++ b/APIs/NetworkControlAPI.raml
@@ -166,11 +166,13 @@ documentation:
       description: >
         Register a new Endpoint.
         The PUT is invoked to inform the network controller about the presence of an Endpoint.
-        The Endpoint schema includes mandatory details of the Network Device the Endpoint is attached to.
+        The Endpoint _should_ include details of the Network Device the Endpoint is attached to.
         The attached network device details can be fetched by the endpoint through LLDP (if the endpoint is LLDP capable)
         or manual entry in the caller of this API (e.g., a broadcast controller).
-        The network _may_ verify these details for security purposes. Verification _may_ happen synchronously, as part of the request.
-        The network controller _must_ create a corresponding Network Link with this Endpoint as the peer device.
+        The network controller _may_ verify these details. If the details are invalid, the network controller _may_ reject the request.
+        When the attached network device details are not included in the request, the network controller _may_ attempt to determine them and include them in the registered Endpoint.
+        However, if the network controller cannot determine them, it may reject the the request.
+        The network controller _should_ create a corresponding Network Link with this Endpoint as the peer device.
         Subsequent PUT requests should receive an error response. Updates should be done using PATCH.
       body:
         type: Endpoint

--- a/APIs/schemas/endpoint-patch.json
+++ b/APIs/schemas/endpoint-patch.json
@@ -25,13 +25,34 @@
       ],
       "properties": {
         "chassis_id": {
-          "type": "string",
-          "description": "MAC address for the peer network device.",
-          "pattern": "^([0-9a-f]{2}-){5}([0-9a-f]{2})$"
+          "description": "Matches the chassis_id of the peer network device. Where LLDP is implemented on the network device interfaces, the LLDP Chassis ID should match this value.",
+          "anyOf": [
+            {
+              "type": "string",
+              "pattern": "^([0-9a-f]{2}-){5}([0-9a-f]{2})$",
+              "description": "When the Chassis ID is a MAC address, use this format."
+            },
+            {
+              "type": "string",
+              "pattern": "^.+$",
+              "description": "When the Chassis ID is anything other than a MAC address, a freeform string may be used."
+            }
+          ]
         },
         "port_id": {
-          "type": "string",
-          "description": "The ifAlias of the peer network device the endpoint is connected to."
+          "description": "Matches the port_id of the interface on the peer network device to which the endpoint is connected. Where LLDP is implemented on the network device interfaces, the LLDP Port ID should match this value.",
+          "anyOf": [
+            {
+              "type": "string",
+              "pattern": "^([0-9a-f]{2}-){5}([0-9a-f]{2})$",
+              "description": "When the Chassis ID is a MAC address, use this format."
+            },
+            {
+              "type": "string",
+              "pattern": "^.+$",
+              "description": "When the Chassis ID is anything other than a MAC address, a freeform string may be used."
+            }
+          ]
         }
       }
     },

--- a/APIs/schemas/endpoint.json
+++ b/APIs/schemas/endpoint.json
@@ -36,7 +36,7 @@
     },
     "port_id": {
       "type": "string",
-      "description": "MAC address of the endpoint.",
+      "description": "MAC address of the endpoint. Where LLDP is implemented on the endpoint, the LLDP Port ID should match this value. Matches to IS-04 nodes' interfaces.port_id and should be same.",
       "pattern": "^([0-9a-f]{2}-){5}([0-9a-f]{2})$"
     },
     "ip_address": {
@@ -60,13 +60,34 @@
       ],
       "properties": {
         "chassis_id": {
-          "type": "string",
-          "description": "MAC address for the peer network device.",
-          "pattern": "^([0-9a-f]{2}-){5}([0-9a-f]{2})$"
+          "description": "Matches the chassis_id of the peer network device. Where LLDP is implemented on the network device interfaces, the LLDP Chassis ID should match this value.",
+          "anyOf": [
+            {
+              "type": "string",
+              "pattern": "^([0-9a-f]{2}-){5}([0-9a-f]{2})$",
+              "description": "When the Chassis ID is a MAC address, use this format."
+            },
+            {
+              "type": "string",
+              "pattern": "^.+$",
+              "description": "When the Chassis ID is anything other than a MAC address, a freeform string may be used."
+            }
+          ]
         },
         "port_id": {
-          "type": "string",
-          "description": "The ifAlias of the peer network device the endpoint is connected to."
+          "description": "Matches the port_id of the interface on the peer network device to which the endpoint is connected. Where LLDP is implemented on the network device interfaces, the LLDP Port ID should match this value.",
+          "anyOf": [
+            {
+              "type": "string",
+              "pattern": "^([0-9a-f]{2}-){5}([0-9a-f]{2})$",
+              "description": "When the Chassis ID is a MAC address, use this format."
+            },
+            {
+              "type": "string",
+              "pattern": "^.+$",
+              "description": "When the Chassis ID is anything other than a MAC address, a freeform string may be used."
+            }
+          ]
         }
       }
     },

--- a/APIs/schemas/endpoint.json
+++ b/APIs/schemas/endpoint.json
@@ -6,8 +6,7 @@
     "id",
     "chassis_id",
     "port_id",
-    "ip_address",
-    "attached_network_device"
+    "ip_address"
   ],
   "properties": {
     "id": {

--- a/APIs/schemas/endpoint.json
+++ b/APIs/schemas/endpoint.json
@@ -80,12 +80,12 @@
             {
               "type": "string",
               "pattern": "^([0-9a-f]{2}-){5}([0-9a-f]{2})$",
-              "description": "When the Chassis ID is a MAC address, use this format."
+              "description": "When the Port ID is a MAC address, use this format."
             },
             {
               "type": "string",
               "pattern": "^.+$",
-              "description": "When the Chassis ID is anything other than a MAC address, a freeform string may be used."
+              "description": "When the Port ID is anything other than a MAC address, a freeform string may be used."
             }
           ]
         }

--- a/APIs/schemas/network-device.json
+++ b/APIs/schemas/network-device.json
@@ -63,12 +63,12 @@
               {
                 "type": "string",
                 "pattern": "^([0-9a-f]{2}-){5}([0-9a-f]{2})$",
-                "description": "When the Chassis ID is a MAC address, use this format."
+                "description": "When the Port ID is a MAC address, use this format."
               },
               {
                 "type": "string",
                 "pattern": "^.+$",
-                "description": "When the Chassis ID is anything other than a MAC address, a freeform string may be used."
+                "description": "When the Port ID is anything other than a MAC address, a freeform string may be used."
               }
             ]
           },

--- a/APIs/schemas/network-device.json
+++ b/APIs/schemas/network-device.json
@@ -16,9 +16,19 @@
       "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
     },
     "chassis_id": {
-      "type": "string",
-      "description": "MAC address of the network device.",
-      "pattern": "^([0-9a-f]{2}-){5}([0-9a-f]{2})$"
+      "description": "A persistent identifier of the network device, often the MAC address. Where LLDP is implemented on the network device interfaces, the LLDP Chassis ID should match this value.",
+      "anyOf": [
+        {
+          "type": "string",
+          "pattern": "^([0-9a-f]{2}-){5}([0-9a-f]{2})$",
+          "description": "When the Chassis ID is a MAC address, use this format."
+        },
+        {
+          "type": "string",
+          "pattern": "^.+$",
+          "description": "When the Chassis ID is anything other than a MAC address, a freeform string may be used."
+        }
+      ]
     },
     "mgmt_ip": {
       "type": "string",
@@ -48,8 +58,19 @@
         ],
         "properties": {
           "port_id": {
-            "description": "The ifAlias of the network device.",
-            "type": "string"
+            "description": "A persistent identifier of the interface on the network device, often the ifAlias. Where LLDP is implemented on the network device interfaces, the LLDP Port ID should match this value.",
+            "anyOf": [
+              {
+                "type": "string",
+                "pattern": "^([0-9a-f]{2}-){5}([0-9a-f]{2})$",
+                "description": "When the Chassis ID is a MAC address, use this format."
+              },
+              {
+                "type": "string",
+                "pattern": "^.+$",
+                "description": "When the Chassis ID is anything other than a MAC address, a freeform string may be used."
+              }
+            ]
           },
           "admin_status": {
             "description": "The administrative status of the interface.",

--- a/APIs/schemas/network-link.json
+++ b/APIs/schemas/network-link.json
@@ -28,12 +28,12 @@
               {
                 "type": "string",
                 "pattern": "^([0-9a-f]{2}-){5}([0-9a-f]{2})$",
-                "description": "When the Chassis ID is a MAC address, use this format."
+                "description": "When the Port ID is a MAC address, use this format."
               },
               {
                 "type": "string",
                 "pattern": "^.+$",
-                "description": "When the Chassis ID is anything other than a MAC address, a freeform string may be used."
+                "description": "When the Port ID is anything other than a MAC address, a freeform string may be used."
               },
               {
                 "type": "null",

--- a/APIs/schemas/network-link.json
+++ b/APIs/schemas/network-link.json
@@ -23,11 +23,17 @@
             "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
           },
           "port_id": {
-            "description": "The ifAlias of the interface of the network device or endpoint.",
+            "description": "When the peer is a network device, matches the port_id of the interface on the network device to which the link is connected. When the peer is an endpoint, this value must be null.",
             "anyOf": [
               {
                 "type": "string",
-                "description": "The ifAlias of the interface of the peer device. This option MUST not be used if the peer is an endpoint."
+                "pattern": "^([0-9a-f]{2}-){5}([0-9a-f]{2})$",
+                "description": "When the Chassis ID is a MAC address, use this format."
+              },
+              {
+                "type": "string",
+                "pattern": "^.+$",
+                "description": "When the Chassis ID is anything other than a MAC address, a freeform string may be used."
               },
               {
                 "type": "null",

--- a/docs/1.0. Overview.md
+++ b/docs/1.0. Overview.md
@@ -27,8 +27,21 @@ Conventions used in the Network Control API that are common with the specificati
 
 The resources that are managed by AMWA IS-06 NMOS Network Control API are specified in the [Data Model](3.0.%20Data%20Model.md).
 
+## LLDP
+
+The Link Layer Discovery Protocol (LLDP), defined by [IEEE 802.1AB](https://standards.ieee.org/standard/802_1AB-2016.html), is a vendor-neutral protocol for network devices (switches) and endpoints to advertise their identity and describe their capabilities.
+
+In order that the broadcast controller and the network controller can communicate about the network topology reliably, this specification strongly recommends LLDP be configured on network devices (switches) and endpoints.
+
+LLDP defines three mandatory parameters including Chassis ID and Port ID.
+
+Where LLDP is implemented, the LLDP identifiers should correspond to the values included in the resources managed by the Network Control API. Otherwise, a broadcast controller may require a manual step to use this API.
+
 ## Relationship with other Specifications
 
 This specification has no dependency on AMWA IS-04 or IS-05. However the overall system is more fully automated with IS-04 and IS-05.
+
+Where LLDP is implemented, this specification recommends that IS-04 Node APIs transmit the Chassis ID and Port ID of each interface, matching the `chassis_id` and `port_id` properties of the `interfaces` in the 'self' resource.
+This specification also recommends that IS-04 Node APIs indicate the received Chassis ID and Port ID of each interface's peer network device in the `chassis_id` and `port_id` properties of the `attached_network_device` for all `interfaces` in the 'self' resource.
 
 ![Architecture Diagram](images/CurrentArchitecture.png)

--- a/docs/3.1. Data Model - Endpoint.md
+++ b/docs/3.1. Data Model - Endpoint.md
@@ -13,7 +13,10 @@ The required parameters for registering the endpoint are:
 * `chassis_id`: The endpoint should provide its MAC address or another identifier permitted by the IEEE Link Layer Discovery Protocol (LLDP) for the Chassis ID parameter
 * `port_id`: The endpoint shall provide its MAC address as permitted by LLDP for the Port ID parameter
 * `ip_address`: The endpoint's IP address that will be used to send and/or receive the flows
-* `attached_network_device`: The switch's Chassis ID and Port ID which should be provided by the switch in the LLDP mandatory parameters
+
+The `attached_network_device`, including the switch's Chassis ID and Port ID, should be included in an endpoint registration request, so that a network controller can verify these details. These values should be provided by the switch in the LLDP mandatory parameters so they can be fetched by the endpoint.
+When these details are not included in the request, the network controller may attempt to determine them and include them in the registered Endpoint.
+However, if the network controller cannot determine them, it may reject the the request.
 
 ![Sequence Diagram](images/Endpoint-information-flow.png)
 

--- a/docs/3.1. Data Model - Endpoint.md
+++ b/docs/3.1. Data Model - Endpoint.md
@@ -10,7 +10,7 @@ The endpoint has to be registered with the Network Controller before it can send
 
 The required parameters for registering the endpoint are:
 * `id`: A unique identifier for this endpoint as explained above
-* `chassis_id`: The endpoint should provide its MAC address or any other information permitted by the IEEE Link Layer Discovery Protocol (LLDP) for the Chassis ID parameter
+* `chassis_id`: The endpoint should provide its MAC address or another identifier permitted by the IEEE Link Layer Discovery Protocol (LLDP) for the Chassis ID parameter
 * `port_id`: The endpoint shall provide its MAC address as permitted by LLDP for the Port ID parameter
 * `ip_address`: The endpoint's IP address that will be used to send and/or receive the flows
 * `attached_network_device`: The switch's Chassis ID and Port ID which should be provided by the switch in the LLDP mandatory parameters

--- a/docs/3.1. Data Model - Endpoint.md
+++ b/docs/3.1. Data Model - Endpoint.md
@@ -10,10 +10,10 @@ The endpoint has to be registered with the Network Controller before it can send
 
 The required parameters for registering the endpoint are:
 * `id`: A unique identifier for this endpoint as explained above
-* `chassis_id`: The endpoint shall provide its MAC address or any information permitted by the IEEE Link Layer Discovery Protocol (LLDP) for the Chassis ID parameter
-* `port_id`: The endpoint shall provide its MAC address as permitted by LLDP for this parameter
+* `chassis_id`: The endpoint should provide its MAC address or any other information permitted by the IEEE Link Layer Discovery Protocol (LLDP) for the Chassis ID parameter
+* `port_id`: The endpoint shall provide its MAC address as permitted by LLDP for the Port ID parameter
 * `ip_address`: The endpoint's IP address that will be used to send and/or receive the flows
-* `attached_network_device`: The switch's MAC address and its ethernet information which are provided by the switch in the LLDP's mandatory Chassis ID and MAC ID parameters
+* `attached_network_device`: The switch's Chassis ID and Port ID which should be provided by the switch in the LLDP mandatory parameters
 
 ![Sequence Diagram](images/Endpoint-information-flow.png)
 

--- a/docs/3.3. Data Model - Network Device.md
+++ b/docs/3.3. Data Model - Network Device.md
@@ -7,11 +7,11 @@ The Network Device (switch) information provided in this data model permits the 
 The parameters of a Network Device are:
 
 * `id`: uniquely identifies a network device
-* `chassis_id`: its chassis ID (same as reported via LLDP)
+* `chassis_id`: its Chassis ID, as should be transmitted via LLDP
 * `mgmt_ip`: its management IP address
 * `mtu`: the global (switch-wide) MTU
 * `interfaces`: an array of interfaces
 
-The interfaces information includes port id (same as transmitted through LLDP), speed, admin and operation status. The interface MTU is optional and can be included if different from the global MTU.
+The interfaces information includes the Port ID, as should be transmitted via LLDP, and the speed, admin and operation status. The interface MTU is optional and can be included if different from the global MTU.
 
 Only a GET operation is permitted on a Network Device.


### PR DESCRIPTION
Align with IS-04 v1.3, TR-1001-1, and allow more flexibility in LLDP implementation on both Network Devices and Endpoints, without introducing any new data types or properties compared to v1.0.

Supersedes #51, based on https://github.com/AMWA-TV/nmos-network-control/pull/51#issuecomment-584613189.
