### PR TITLE
attached_network_device (merge to lldp-2 branch)

### DIFF
--- a/APIs/NetworkControlAPI.raml
+++ b/APIs/NetworkControlAPI.raml
@@ -164,7 +164,14 @@ documentation:
             type: ErrorSchema
     put:
       description: >
-        Register a new Endpoint. The PUT is invoked to inform the network controller about the presence of an Endpoint. The Endpoint schema includes mandatory details of the Network Device the Endpoint is attached to. The attached network device details can be fetched by the endpoint through LLDP (if the endpoint is LLDP capable) or manual entry in the caller of this API (e.g., a broadcast controller). The network _may_ verify these details for security purposes. Verification _may_ happen synchronously, as part of the request. The network controller _must_ create a corresponding Network Link with this Endpoint as the peer device. Subsequent PUT requests should receive an error response. Updates should be done using PATCH.
+        Register a new Endpoint.
+        The PUT is invoked to inform the network controller about the presence of an Endpoint.
+        The Endpoint schema includes mandatory details of the Network Device the Endpoint is attached to.
+        The attached network device details can be fetched by the endpoint through LLDP (if the endpoint is LLDP capable)
+        or manual entry in the caller of this API (e.g., a broadcast controller).
+        The network _may_ verify these details for security purposes. Verification _may_ happen synchronously, as part of the request.
+        The network controller _must_ create a corresponding Network Link with this Endpoint as the peer device.
+        Subsequent PUT requests should receive an error response. Updates should be done using PATCH.
       body:
         type: Endpoint
         example: !include ../examples/netctrl-endpoint-put-request.json

--- a/APIs/NetworkControlAPI.raml
+++ b/APIs/NetworkControlAPI.raml
@@ -166,11 +166,13 @@ documentation:
       description: >
         Register a new Endpoint.
         The PUT is invoked to inform the network controller about the presence of an Endpoint.
-        The Endpoint schema includes mandatory details of the Network Device the Endpoint is attached to.
+        The Endpoint _should_ include details of the Network Device the Endpoint is attached to.
         The attached network device details can be fetched by the endpoint through LLDP (if the endpoint is LLDP capable)
         or manual entry in the caller of this API (e.g., a broadcast controller).
-        The network _may_ verify these details for security purposes. Verification _may_ happen synchronously, as part of the request.
-        The network controller _must_ create a corresponding Network Link with this Endpoint as the peer device.
+        The network controller _may_ verify these details. If the details are invalid, the network controller _may_ reject the request.
+        When the attached network device details are not included in the request, the network controller _may_ attempt to determine them and include them in the registered Endpoint.
+        However, if the network controller cannot determine them, it may reject the the request.
+        The network controller _should_ create a corresponding Network Link with this Endpoint as the peer device.
         Subsequent PUT requests should receive an error response. Updates should be done using PATCH.
       body:
         type: Endpoint

--- a/APIs/schemas/endpoint.json
+++ b/APIs/schemas/endpoint.json
@@ -6,8 +6,7 @@
     "id",
     "chassis_id",
     "port_id",
-    "ip_address",
-    "attached_network_device"
+    "ip_address"
   ],
   "properties": {
     "id": {

--- a/docs/3.1. Data Model - Endpoint.md
+++ b/docs/3.1. Data Model - Endpoint.md
@@ -13,7 +13,10 @@ The required parameters for registering the endpoint are:
 * `chassis_id`: The endpoint should provide its MAC address or another identifier permitted by the IEEE Link Layer Discovery Protocol (LLDP) for the Chassis ID parameter
 * `port_id`: The endpoint shall provide its MAC address as permitted by LLDP for the Port ID parameter
 * `ip_address`: The endpoint's IP address that will be used to send and/or receive the flows
-* `attached_network_device`: The switch's Chassis ID and Port ID which should be provided by the switch in the LLDP mandatory parameters
+
+The `attached_network_device`, including the switch's Chassis ID and Port ID, should be included in an endpoint registration request, so that a network controller can verify these details. These values should be provided by the switch in the LLDP mandatory parameters so they can be fetched by the endpoint.
+When these details are not included in the request, the network controller may attempt to determine them and include them in the registered Endpoint.
+However, if the network controller cannot determine them, it may reject the the request.
 
 ![Sequence Diagram](images/Endpoint-information-flow.png)
 


### PR DESCRIPTION
Make Endpoint `attached_network_device` optional - though strongly recommended - to allow operation in the case that these details are not available to the BC, cf. IS-04 Node **/self** `interfaces.attached_network_device` being optional.

Reasonable?