### PR TITLE
Use schema property "dependencies" to prohibit wildcard IP address matching

### DIFF
--- a/APIs/schemas/network-address-translation-tuple.json
+++ b/APIs/schemas/network-address-translation-tuple.json
@@ -3,28 +3,7 @@
   "type": "object",
   "description": "Describes the 4-tuple of IP Addresses and/or Ports to be matched or translated to.",
   "title": "Network address translation 4-tuple",
-  "anyOf": [
-    {
-      "required": [
-        "source_ip"
-      ]
-    },
-    {
-      "required": [
-        "source_port"
-      ]
-    },
-    {
-      "required": [
-        "destination_ip"
-      ]
-    },
-    {
-      "required": [
-        "destination_port"
-      ]
-    }
-  ],
+  "additionalProperties": false,
   "properties": {
     "source_ip": {
       "type": "string",

--- a/APIs/schemas/network-address-translation.json
+++ b/APIs/schemas/network-address-translation.json
@@ -5,6 +5,7 @@
   "title": "Network address translation policy",
   "required": [
     "id",
+    "match",
     "translated",
     "receiver_endpoint_ids"
   ],
@@ -19,10 +20,25 @@
       "description": "Translation policy name."
     },
     "match": {
-      "$ref": "network-address-translation-tuple.json"
+      "allOf": [
+        {
+          "dependencies": {
+            "source_port": ["source_ip"],
+            "destination_port": ["destination_ip"]
+          }
+        }, {
+          "$ref": "network-address-translation-tuple.json"
+        }
+      ]
     },
     "translated": {
-      "$ref": "network-address-translation-tuple.json"
+      "allOf": [
+        {
+          "minProperties": 1
+        }, {
+          "$ref": "network-address-translation-tuple.json"
+        }
+      ]
     },
     "receiver_endpoint_ids": {
       "type": "array",


### PR DESCRIPTION
If source or destination port is included in the "match" constraints, the related IP address must also be matched. The "match" tuple is also made required.

If matching on only source IP address (and optionally port) is not needed, we can also make `"destination_ip"` required.
